### PR TITLE
Bump picocsv from 2.4.0 to 2.5.1

### DIFF
--- a/picocsv/build.gradle.kts
+++ b/picocsv/build.gradle.kts
@@ -1,4 +1,4 @@
 dependencies {
     jmh(rootProject)
-    implementation("com.github.nbbrd.picocsv:picocsv:2.4.0")
+    implementation("com.github.nbbrd.picocsv:picocsv:2.5.1")
 }


### PR DESCRIPTION
This release should stabilize performances on read ... I'm eager to find out ;)